### PR TITLE
Add check to verify if webAuthUser is email address 

### DIFF
--- a/services/auth/reverseproxy.go
+++ b/services/auth/reverseproxy.go
@@ -39,6 +39,8 @@ type ReverseProxy struct{}
 func (r *ReverseProxy) getUserName(req *http.Request) string {
 	webAuthUser := strings.TrimSpace(req.Header.Get(setting.ReverseProxyAuthUser))
 	if len(webAuthUser) == 0 {
+		email := req.Header.Get(setting.ReverseProxyAuthEmail)
+		webAuthUser := email[:strings.Index(email, '@')]
 		return ""
 	}
 	return webAuthUser


### PR DESCRIPTION
We need to get login name from the email if it's REVERSE_PROXY_AUTHENTICATION_USER is empty.

<!--
Description : There are scenarios where application accepts X-WEBAUTH-USER as email address, which ends up  "must be valid alpha or numeric or dash(-_) or dot characters" error.

Issue : https://github.com/go-gitea/gitea/issues/20433 

-->  
